### PR TITLE
Modify mobile toolbar styles for bottom positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,8 +3,8 @@
         height: 100%;
         .mobile-toolbar-options-list-container {
             border-radius: 5px;
-            /* The TS code above will override the 25px fallback */
-            bottom: var(--double_row_mobile_toolbar_bottom_offset, 25px);
+            bottom: 0;
+            margin-bottom: env(safe-area-inset-bottom, 0);
             position: relative;
             height: 70px;
 


### PR DESCRIPTION
Updated mobile toolbar options styles to remove fallback and set bottom margin.
Line 7: Changed bottom property to 0 to kill the artificial floating gap.
Line 8: Added margin-bottom: env(safe-area-inset-bottom, 0) to dynamically hug the native navigation bar or keyboard edge without relying on injected JS fallbacks.